### PR TITLE
🐛 呼び出すメソッドを正しいものに

### DIFF
--- a/src/Traq.Bot/TraqBot.cs
+++ b/src/Traq.Bot/TraqBot.cs
@@ -91,9 +91,9 @@ namespace Traq.Bot
                 case TraqBotEvents.UserGroupMemberRemoved:
                     return OnUserGroupMemberRemovedAsync(body.Deserialize<UserGroupMemberEventArgs>().MustNotNull(), ct);
                 case TraqBotEvents.UserGroupAdminAdded:
-                    return OnUserGroupMemberAddedAsync(body.Deserialize<UserGroupMemberEventArgs>().MustNotNull(), ct);
+                    return OnUserGroupAdminAddedAsync(body.Deserialize<UserGroupMemberEventArgs>().MustNotNull(), ct);
                 case TraqBotEvents.UserGroupAdminRemoved:
-                    return OnUserGroupMemberAddedAsync(body.Deserialize<UserGroupMemberEventArgs>().MustNotNull(), ct);
+                    return OnUserGroupAdminRemovedAsync(body.Deserialize<UserGroupMemberEventArgs>().MustNotNull(), ct);
                 #endregion
 
                 #region Stamp Events


### PR DESCRIPTION
- `USER_GROUP_ADMIN_ADDED`, `USER_GROUP_ADMIN_REMOVED` イベントで呼び出されるメソッドが間違っていた.